### PR TITLE
Makes stuff in header-bar (.button .title .subtitle) look different when window not focused

### DIFF
--- a/MosSky/gtk-3.0/gtk-widgets.css
+++ b/MosSky/gtk-3.0/gtk-widgets.css
@@ -2200,12 +2200,19 @@ GtkColorButton.button {
     
 }
 
+.header-bar .title:backdrop {
+    color: @titlebar_unfocused_text_color;
+}
+
 .header-bar .subtitle {
 	font-size: 90%;
 	padding: 0px 12px 0px 12px;
 	color: shade (@theme_fg_color, 1.12);
 }
 
+.header-bar .subtitle:backdrop {
+    color: shade(@titlebar_unfocused_text_color, 1.12);
+}
 
 .header-bar GtkComboBox,
 .header-bar .button {
@@ -2272,6 +2279,10 @@ GtkColorButton.button {
     border-bottom-color: shade(@theme_bg_color, 0.6);
     background-color: shade(@titlebar_bg_color, 0.80);
     background-image: none;
+}
+
+.header-bar .button:backdrop {
+    color: @titlebar_unfocused_text_color;
 }
 
 .header-bar .entry {


### PR DESCRIPTION
I think we should also make the header bar look different when window is not focused, so it's consistent with what you did in your last commit.