### PR TITLE
gets rid off the bg color of '.show-apps .overview-icon'

### DIFF
--- a/MosCloud/gnome-shell/gnome-shell.css
+++ b/MosCloud/gnome-shell/gnome-shell.css
@@ -1203,7 +1203,6 @@ StScrollBar {
 
 .show-apps .overview-icon {
   padding: 11px;
-  background-color: rgba(0, 0, 0, 0.5);
   border-radius: 2px;
   border: 0px solid; }
 


### PR DESCRIPTION
So it has the same bg color as the other icons on the dash when not hovered.

Great theme as always!