### PR TITLE
Changed undershoot element

### DIFF
--- a/MosCloud/gtk-3.0/gtk-widgets.css
+++ b/MosCloud/gtk-3.0/gtk-widgets.css
@@ -2423,7 +2423,42 @@ GtkColorButton.button {
   border: none;
   box-shadow: none; }
 
-.undershoot.top, .undershoot.right, .undershoot.bottom, .undershoot.left { background-image: none; }
+.undershoot.top {
+  background-color: transparent;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-top: 1px;
+  background-size: 10px 1px;
+  background-repeat: repeat-x;
+  background-origin: content-box;
+  background-position: center top; }
+
+.undershoot.bottom {
+  background-color: transparent;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-bottom: 1px;
+  background-size: 10px 1px;
+  background-repeat: repeat-x;
+  background-origin: content-box;
+  background-position: center bottom; }
+
+.undershoot.left {
+  background-color: transparent;
+  background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-left: 1px;
+  background-size: 1px 10px;
+  background-repeat: repeat-y;
+  background-origin: content-box;
+  background-position: left center; }
+
+.undershoot.right {
+  background-color: transparent;
+  background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
+  padding-right: 1px;
+  background-size: 1px 10px;
+  background-repeat: repeat-y;
+  background-origin: content-box;
+  background-position: right center; }
+
 
 .overlay-bar {
   background-color: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
The undershoot element was just an empty image. Because of this the elements on Nautilus' sidebar were obscured by a gray rectangle if the list was longer than the window's height. I copied the definitions from the Arc Theme.